### PR TITLE
Add tests, and throw when no cutie found

### DIFF
--- a/javascript/index.js
+++ b/javascript/index.js
@@ -1,8 +1,11 @@
 module.exports = MaybeHug
 
 function MaybeHug (cutie) {
-  if (!this) {
-    new MaybeHug(cutie).hug()
+  if (cutie === null || cutie === undefined) {
+    throw new TypeError("no cutie to maybe hug :(")
+  }
+  if (!(this instanceof MaybeHug)) {
+    return new MaybeHug(cutie).hug()
   } else {
     this.cutie = cutie
   }

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -4,7 +4,7 @@
   "description": "Conditional hugging implementation for JavaScript",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "tap test/*.js"
   },
   "repository": {
     "type": "git",
@@ -19,5 +19,8 @@
   "bugs": {
     "url": "https://github.com/zkat/maybe-hugs/issues"
   },
-  "homepage": "https://github.com/zkat/maybe-hugs#readme"
+  "homepage": "https://github.com/zkat/maybe-hugs#readme",
+  "devDependencies": {
+    "tap": "^1.3.2"
+  }
 }

--- a/javascript/test/hugs.js
+++ b/javascript/test/hugs.js
@@ -1,0 +1,49 @@
+var t = require("tap")
+var maybeHugs = require("../")
+
+t.test("cutie is required", function (t) {
+  t.throws(function () {
+    maybeHugs()
+  })
+  t.throws(function () {
+    new maybeHugs().hug()
+  })
+  t.end()
+})
+
+t.test("empathy test", function (t) {
+  var noHugs = [
+    { acceptsHugs: false },
+    { acceptsHugs: null },
+    { acceptsHugs: "" },
+    { acceptsHugs: 0 },
+    {},
+    "asdf",
+    "",
+    false,
+    true,
+    10,
+  ]
+  t.plan(noHugs.length * 2)
+  noHugs.forEach(function (nh) {
+    t.equal(maybeHugs(nh), "Empathy!")
+    t.equal(new maybeHugs(nh).hug(), "Empathy!")
+  })
+})
+
+t.test("hug test", function (t) {
+  var yesHugs = [
+    { acceptsHugs: true },
+    { acceptsHugs: 1000 },
+    { acceptsHugs: [] },
+    { acceptsHugs: {} },
+    { acceptsHugs: /^hugs?/ },
+    new (function Huggee () { this.acceptsHugs = this }),
+  ]
+
+  t.plan(yesHugs.length * 2)
+  yesHugs.forEach(function (yh) {
+    t.equal(maybeHugs(yh), "HUG!")
+    t.equal(new maybeHugs(yh).hug(), "HUG!")
+  })
+})


### PR DESCRIPTION
This adds tests, but also makes some slight semantic changes that I
think may have been the original intent.

With this change, calling `MaybeHug(cutie)` returns either `'HUG!'` or
`'Empathy!'`, rather than returning nothing.

Passing null or undefined as the cutie causes it to eagerly throw a
TypeError, rather than throwing later when it tries to hug.  (In other
words, don't try to hug ghosts like null and undefined, they never like
it, and are offended by the offer.)

There is now 100% test coverage as well.
